### PR TITLE
FRGT-2: Let the user choose either to copy the subject or use the full image directly

### DIFF
--- a/ForgetMeNot/Features/ImageProcessing/ImageLiftView.swift
+++ b/ForgetMeNot/Features/ImageProcessing/ImageLiftView.swift
@@ -1,11 +1,3 @@
-//
-//  ImageLiftView.swift
-//  MyFirstApp
-//
-//  Created by Mainul Hossain on 8/4/25.
-//
-
-
 import SwiftUI
 
 struct ImageLiftView: View {
@@ -13,9 +5,64 @@ struct ImageLiftView: View {
     let onSubjectCopied: (UIImage) -> Void
     @State private var observer: NSObjectProtocol?
 
+    private let buttonHeight: CGFloat = 72
+
     var body: some View {
-        VStack {
-            ImageLift(uiImage: uiImage)
+        ZStack {
+            VisualEffectBlur(blurStyle: .systemUltraThinMaterialDark)
+                .ignoresSafeArea()
+            GeometryReader { geo in
+                VStack(spacing: 0) {
+                    // Larger, more readable instruction
+                    Text("🖐️ Long-press to extract subject\n📸 Tap below to save full image")
+                        .font(.system(size: 18, weight: .semibold))
+                        .foregroundColor(.white.opacity(0.91))
+                        .multilineTextAlignment(.center)
+                        .padding(.top, 32)
+                        .padding(.horizontal, 18)
+                        .lineLimit(2)
+                        .minimumScaleFactor(0.92)
+
+                    Spacer(minLength: 0)
+
+                    // Image with rounded corners and shadow
+                    ZStack {
+                        ImageLift(uiImage: uiImage)
+                            .aspectRatio(contentMode: .fit)
+                            .frame(
+                                maxWidth: max(0, geo.size.width * 0.97),
+                                maxHeight: max(0, geo.size.height - buttonHeight - 95)
+                            )
+                            .clipShape(RoundedRectangle(cornerRadius: 22, style: .continuous))
+                            .shadow(color: .black.opacity(0.14), radius: 15, y: 6)
+                    }
+
+                    Spacer(minLength: 0)
+
+                    // Button
+                    Button {
+                        onSubjectCopied(uiImage)
+                    } label: {
+                        Label("Store Full Image", systemImage: "photo.on.rectangle")
+                            .font(.system(size: 19, weight: .semibold))
+                            .frame(maxWidth: .infinity)
+                            .padding(.vertical, 18)
+                            .background(
+                                LinearGradient(
+                                    colors: [Color.accentColor, Color.blue.opacity(0.92)],
+                                    startPoint: .leading, endPoint: .trailing
+                                )
+                            )
+                            .foregroundColor(.white)
+                            .cornerRadius(15)
+                            .shadow(color: Color.blue.opacity(0.17), radius: 11, y: 3)
+                    }
+                    .padding(.horizontal, 20)
+                    .padding(.bottom, 18)
+                    .frame(height: buttonHeight)
+                }
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+            }
         }
         .onAppear {
             observer = NotificationCenter.default.addObserver(
@@ -35,3 +82,13 @@ struct ImageLiftView: View {
         }
     }
 }
+
+// Helper for background blur
+struct VisualEffectBlur: UIViewRepresentable {
+    var blurStyle: UIBlurEffect.Style
+    func makeUIView(context: Context) -> UIVisualEffectView {
+        UIVisualEffectView(effect: UIBlurEffect(style: blurStyle))
+    }
+    func updateUIView(_ uiView: UIVisualEffectView, context: Context) { }
+}
+

--- a/ForgetMeNot/Features/TravelPlan/NewTravelPlanView.swift
+++ b/ForgetMeNot/Features/TravelPlan/NewTravelPlanView.swift
@@ -52,76 +52,172 @@ struct NewTravelPlanView: View {
 
     var body: some View {
         NavigationStack {
-            ScrollView(.vertical, showsIndicators: true) {
-                VStack(alignment: .leading, spacing: 18) {
-                    TextField("Plan Name", text: $planName)
-                        .font(.title2)
-                        .textFieldStyle(.roundedBorder)
-                    Text("Travel Date & Time")
-                        .font(.headline)
-                    DatePicker("", selection: $travelDate, displayedComponents: [.date, .hourAndMinute])
-                        .labelsHidden()
-                        .padding(.bottom, 8)
-                    Text("When should we remind you?")
-                        .font(.headline)
-                    DatePicker("", selection: $reminderDate, in: ...travelDate, displayedComponents: [.date, .hourAndMinute])
-                        .labelsHidden()
-                        .padding(.bottom, 16)
-                    Text("Tasks").font(.headline)
-                    ForEach(tasks.indices, id: \.self) { idx in
-                        HStack {
-                            TextField("Task...", text: Binding(
-                                get: { tasks[idx].title },
-                                set: { tasks[idx].title = $0 }
-                            ))
-                            .textFieldStyle(.roundedBorder)
-                            if let id = tasks[idx].subjectImageID,
-                               let subj = subjects.first(where: { $0.id == id }),
-                               let thumb = subj.thumbnail {
-                                Button {
-                                    showSubjectPreview = subj
-                                } label: {
-                                    Image(uiImage: thumb)
-                                        .resizable()
-                                        .frame(width: 38, height: 38)
-                                        .clipShape(RoundedRectangle(cornerRadius: 8))
-                                }
-                            }
-                            Button {
-                                editingTaskIndex = idx
-                                showImageSourcePicker = true
-                            } label: {
-                                Image(systemName: "photo.badge.plus")
-                            }
-                            .buttonStyle(.plain)
-                            if tasks.count > 1 {
-                                Button {
-                                    tasks.remove(at: idx)
-                                } label: {
-                                    Image(systemName: "minus.circle")
-                                        .foregroundColor(.red)
-                                }
-                                .buttonStyle(.plain)
-                            }
+            ScrollView(.vertical, showsIndicators: false) {
+                VStack(spacing: 26) {
+                    // PLAN DETAILS CARD
+                    VStack(spacing: 20) {
+                        TextField("Give your plan a name...", text: $planName)
+                            .padding(.vertical, 16)
+                            .padding(.horizontal, 22)
+                            .font(.system(size: 22, weight: .semibold))
+                            .background(Color(.systemGray6))
+                            .cornerRadius(16)
+                            .shadow(color: Color.black.opacity(0.03), radius: 2, y: 1)
+
+                        VStack(alignment: .leading, spacing: 14) {
+                            Text("Travel Date & Time")
+                                .font(.system(size: 17, weight: .bold))
+                                .foregroundColor(.secondary)
+                            DatePicker("", selection: $travelDate, displayedComponents: [.date, .hourAndMinute])
+                                .labelsHidden()
+                                .datePickerStyle(.compact)
+                        }
+
+                        VStack(alignment: .leading, spacing: 14) {
+                            Text("Reminder")
+                                .font(.system(size: 17, weight: .bold))
+                                .foregroundColor(.secondary)
+                            DatePicker("", selection: $reminderDate, in: ...travelDate, displayedComponents: [.date, .hourAndMinute])
+                                .labelsHidden()
+                                .datePickerStyle(.compact)
                         }
                     }
-                    Button {
-                        tasks.append(TravelTask(title: ""))
-                    } label: {
-                        Label("Add Task", systemImage: "plus")
-                            .padding(.vertical, 4)
-                    }
+                    .padding()
+                    .background(.ultraThinMaterial)
+                    .cornerRadius(22)
+                    .shadow(color: Color.black.opacity(0.08), radius: 16, y: 6)
+                    .padding(.horizontal, 10)
                     .padding(.top, 8)
+
+                    // TASKS CARD
+                    VStack(spacing: 18) {
+                        HStack {
+                            Text("Tasks")
+                                .font(.system(size: 20, weight: .bold))
+                                .foregroundColor(.primary)
+                            Spacer()
+                        }
+
+                        ForEach(tasks.indices, id: \.self) { idx in
+                            HStack(alignment: .center, spacing: 12) {
+                                // SUBJECT IMAGE THUMBNAIL (modern style)
+                                if let id = tasks[idx].subjectImageID,
+                                   let subj = subjects.first(where: { $0.id == id }),
+                                   let thumb = subj.thumbnail {
+                                    Button {
+                                        showSubjectPreview = subj
+                                    } label: {
+                                        Image(uiImage: thumb)
+                                            .resizable()
+                                            .aspectRatio(contentMode: .fill)
+                                            .frame(width: 48, height: 48)
+                                            .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
+                                            .overlay(
+                                                RoundedRectangle(cornerRadius: 16)
+                                                    .stroke(Color.white.opacity(0.9), lineWidth: 2)
+                                            )
+                                            .shadow(color: Color.black.opacity(0.13), radius: 8, y: 3)
+                                            .padding(.trailing, 2)
+                                            .transition(.scale.combined(with: .opacity))
+                                    }
+                                    .buttonStyle(.plain)
+                                } else {
+                                    Button {
+                                        editingTaskIndex = idx
+                                        showImageSourcePicker = true
+                                    } label: {
+                                        ZStack {
+                                            RoundedRectangle(cornerRadius: 16)
+                                                .fill(Color(.systemGray5))
+                                                .frame(width: 48, height: 48)
+                                            Image(systemName: "photo.on.rectangle")
+                                                .resizable()
+                                                .aspectRatio(contentMode: .fit)
+                                                .frame(width: 28, height: 28)
+                                                .foregroundColor(.blue.opacity(0.82))
+                                            Image(systemName: "plus.circle.fill")
+                                                .resizable()
+                                                .foregroundColor(.accentColor)
+                                                .background(Color.white, in: Circle())
+                                                .frame(width: 21, height: 21)
+                                                .offset(x: 14, y: 14) // lower right overlap
+                                                .shadow(color: .black.opacity(0.13), radius: 2, x: 1, y: 1)
+                                        }
+                                    }
+                                    .buttonStyle(.plain)
+                                    .padding(.trailing, 2)
+
+                                }
+
+                                // TASK FIELD
+                                TextField("What to do?", text: Binding(
+                                    get: { tasks[idx].title },
+                                    set: { tasks[idx].title = $0 }
+                                ))
+                                .padding(.vertical, 12)
+                                .padding(.horizontal, 12)
+                                .background(Color(.systemGray6))
+                                .cornerRadius(12)
+                                .font(.system(size: 17, weight: .regular))
+
+                                // REMOVE TASK
+                                if tasks.count > 1 {
+                                    Button {
+                                        tasks.remove(at: idx)
+                                    } label: {
+                                        Image(systemName: "minus.circle.fill")
+                                            .foregroundColor(.red)
+                                            .font(.system(size: 22, weight: .semibold))
+                                    }
+                                    .buttonStyle(.plain)
+                                    .padding(.leading, 4)
+                                }
+                            }
+                            .padding(.vertical, 4)
+                            .padding(.horizontal, 4)
+                            .background(.ultraThinMaterial)
+                            .cornerRadius(18)
+                            .shadow(color: Color.black.opacity(0.04), radius: 2, y: 1)
+                        }
+
+                        // ADD TASK BUTTON (floating style)
+                        Button {
+                            withAnimation(.spring()) {
+                                tasks.append(TravelTask(title: ""))
+                            }
+                        } label: {
+                            Label("Add Task", systemImage: "plus.circle.fill")
+                                .font(.system(size: 19, weight: .semibold))
+                                .padding(.vertical, 11)
+                                .padding(.horizontal, 18)
+                                .background(Color.accentColor.opacity(0.92))
+                                .foregroundColor(.white)
+                                .cornerRadius(14)
+                                .shadow(color: Color.accentColor.opacity(0.17), radius: 8, y: 2)
+                        }
+                        .padding(.top, 8)
+                        .frame(maxWidth: .infinity, alignment: .center)
+                    }
+                    .padding()
+                    .background(.ultraThinMaterial)
+                    .cornerRadius(22)
+                    .shadow(color: Color.black.opacity(0.07), radius: 14, y: 4)
+                    .padding(.horizontal, 10)
+
+                    Spacer(minLength: 20)
                 }
-                .padding()
+                .padding(.bottom, 32)
             }
             .navigationTitle("New Travel Plan")
+            .navigationBarTitleDisplayMode(.inline)
             .toolbar {
                 ToolbarItem(placement: .confirmationAction) {
                     Button("Done") { savePlan() }
+                        .font(.system(size: 17, weight: .semibold))
                 }
                 ToolbarItem(placement: .cancellationAction) {
                     Button("Cancel") { cancel() }
+                        .font(.system(size: 17, weight: .regular))
                 }
             }
             .alert("Plan name is required.", isPresented: $showNameError) {

--- a/ForgetMeNot/Root/ContentView.swift
+++ b/ForgetMeNot/Root/ContentView.swift
@@ -10,66 +10,186 @@ struct ContentView: View {
 
     var body: some View {
         NavigationStack {
-            VStack(spacing: 0) {
-                // Header
-                VStack(spacing: 4) {
-                    Text("🧳 ForgetMeNot")
-                        .font(.largeTitle.bold())
-                        .foregroundColor(.blue)
-                    Text("Let your iPhone remember important details!")
-                        .foregroundColor(.secondary)
-                }
-                .padding(.top, 40)
-                .padding(.bottom, 20)
-
-                Button {
-                    showNewPlan = true
-                } label: {
-                    Label("Create a New Travel Plan", systemImage: "plus.circle.fill")
-                        .font(.headline)
-                        .padding()
-                        .frame(maxWidth: .infinity)
-                        .background(Color.blue.opacity(0.1))
-                        .cornerRadius(12)
-                }
-                .padding(.horizontal)
-                .sheet(isPresented: $showNewPlan) {
-                    NewTravelPlanView { newPlan in
-                        if let plan = newPlan { selectedPlan = plan }
-                        showNewPlan = false
+            ScrollView {
+                VStack(spacing: 0) {
+                    // Header Card
+                    VStack(spacing: 6) {
+                        Text("🧳 ForgetMeNot")
+                            .font(.system(size: 34, weight: .bold, design: .rounded))
+                            .foregroundColor(.blue)
+                        Text("Let your iPhone remember important details!")
+                            .foregroundColor(.secondary)
+                            .font(.system(size: 18, weight: .medium))
+                            .multilineTextAlignment(.center)
                     }
-                }
+                    .padding(.vertical, 24)
+                    .padding(.horizontal, 14)
+                    .background(.ultraThinMaterial)
+                    .cornerRadius(26)
+                    .shadow(color: Color.blue.opacity(0.04), radius: 8, y: 3)
+                    .padding(.horizontal, 14)
+                    .padding(.top, 30)
 
-                if plans.isEmpty {
-                    Text("No travel plans yet.\nTap 'Create a New Travel Plan' to get started!")
-                        .foregroundColor(.gray)
-                        .multilineTextAlignment(.center)
-                        .padding(.top, 60)
-                        .frame(maxWidth: .infinity)
-                } else {
-                    List {
-                        ForEach(plans) { plan in
-                            Button {
-                                selectedPlan = plan
-                            } label: {
-                                VStack(alignment: .leading) {
-                                    Text(plan.name).font(.headline)
-                                    Text(plan.date, style: .date).foregroundColor(.gray)
+                    // New Plan Button
+                    Button {
+                        showNewPlan = true
+                    } label: {
+                        Label("Create a New Travel Plan", systemImage: "plus.circle.fill")
+                            .font(.system(size: 20, weight: .bold))
+                            .padding(.vertical, 18)
+                            .frame(maxWidth: .infinity)
+                            .background(
+                                LinearGradient(
+                                    colors: [Color.blue.opacity(0.12), Color.accentColor.opacity(0.11)],
+                                    startPoint: .leading, endPoint: .trailing
+                                )
+                            )
+                            .cornerRadius(15)
+                            .shadow(color: Color.accentColor.opacity(0.06), radius: 6, y: 2)
+                    }
+                    .padding(.horizontal, 24)
+                    .padding(.top, 18)
+                    .sheet(isPresented: $showNewPlan) {
+                        NewTravelPlanView { newPlan in
+                            if let plan = newPlan { selectedPlan = plan }
+                            showNewPlan = false
+                        }
+                    }
+
+                    // Sections
+                    let incompletePlans = plans.filter { !$0.isCompleted }
+                    let completedPlans = plans.filter { $0.isCompleted }
+
+                    if plans.isEmpty {
+                        VStack {
+                            Spacer(minLength: 60)
+                            Text("No travel plans yet.\nTap 'Create a New Travel Plan' to get started!")
+                                .font(.title3.weight(.medium))
+                                .foregroundColor(.gray)
+                                .multilineTextAlignment(.center)
+                                .padding()
+                        }
+                    } else {
+                        // Incomplete
+                        if !incompletePlans.isEmpty {
+                            SectionHeader(text: "Upcoming Plans", systemImage: "clock")
+                                .padding(.top, 28)
+                                .padding(.leading, 8)
+                            VStack(spacing: 14) {
+                                ForEach(incompletePlans) { plan in
+                                    PlanCard(plan: plan, isCompleted: false) {
+                                        selectedPlan = plan
+                                    }
+                                    .swipeActions(edge: .trailing, allowsFullSwipe: true) {
+                                        Button(role: .destructive) {
+                                            modelContext.delete(plan)
+                                        } label: {
+                                            Label("Delete", systemImage: "trash")
+                                        }
+                                    }
                                 }
                             }
+                            .padding(.horizontal, 14)
                         }
-                        .onDelete { idx in
-                            idx.map { modelContext.delete(plans[$0]) }
+
+                        // Completed
+                        if !completedPlans.isEmpty {
+                            SectionHeader(text: "Completed", systemImage: "checkmark.seal")
+                                .padding(.top, incompletePlans.isEmpty ? 36 : 24)
+                                .padding(.leading, 8)
+                            VStack(spacing: 14) {
+                                ForEach(completedPlans) { plan in
+                                    PlanCard(plan: plan, isCompleted: true) {
+                                        selectedPlan = plan
+                                    }
+                                    .opacity(0.7)
+                                    .swipeActions(edge: .trailing, allowsFullSwipe: true) {
+                                        Button(role: .destructive) {
+                                            modelContext.delete(plan)
+                                        } label: {
+                                            Label("Delete", systemImage: "trash")
+                                        }
+                                    }
+                                }
+                            }
+                            .padding(.horizontal, 14)
+                            .padding(.bottom, 16)
                         }
                     }
-                    .listStyle(.insetGrouped)
+
+                    Spacer(minLength: 60)
                 }
-                Spacer()
             }
+            .background(Color(.systemGroupedBackground).ignoresSafeArea())
             .navigationDestination(item: $selectedPlan) { plan in
                 TravelPlanDetailView(plan: plan)
             }
         }
+    }
+}
+
+// MARK: - Section Header
+struct SectionHeader: View {
+    let text: String
+    let systemImage: String
+    var body: some View {
+        HStack(spacing: 9) {
+            Image(systemName: systemImage)
+                .foregroundColor(.accentColor)
+                .font(.system(size: 17, weight: .bold))
+            Text(text)
+                .font(.system(size: 18, weight: .semibold))
+                .foregroundColor(.secondary)
+            Spacer()
+        }
+    }
+}
+
+// MARK: - Plan Card
+struct PlanCard: View {
+    let plan: TravelPlan
+    let isCompleted: Bool
+    let onTap: () -> Void
+
+    var body: some View {
+        Button {
+            onTap()
+        } label: {
+            HStack(spacing: 16) {
+                ZStack {
+                    RoundedRectangle(cornerRadius: 16, style: .continuous)
+                        .fill(isCompleted ? Color.green.opacity(0.09) : Color.blue.opacity(0.07))
+                        .frame(width: 56, height: 56)
+                    Image(systemName: isCompleted ? "checkmark.circle.fill" : "airplane.departure")
+                        .font(.system(size: 26, weight: .bold))
+                        .foregroundColor(isCompleted ? .green : .blue)
+                }
+                VStack(alignment: .leading, spacing: 5) {
+                    Text(plan.name)
+                        .font(.system(size: 19, weight: .semibold))
+                        .foregroundColor(.primary)
+                        .lineLimit(1)
+                    HStack(spacing: 8) {
+                        Image(systemName: "calendar")
+                            .font(.system(size: 14, weight: .medium))
+                            .foregroundColor(.secondary)
+                        Text(plan.date, style: .date)
+                            .font(.system(size: 16, weight: .medium))
+                            .foregroundColor(.secondary)
+                    }
+                }
+                Spacer()
+                Image(systemName: "chevron.right")
+                    .foregroundColor(.gray)
+                    .opacity(0.7)
+            }
+            .padding(.vertical, 12)
+            .padding(.horizontal, 16)
+            .background(.thinMaterial)
+            .cornerRadius(20)
+            .shadow(color: .black.opacity(0.05), radius: 8, y: 2)
+        }
+        .buttonStyle(.plain)
     }
 }
 


### PR DESCRIPTION
- Implemented option for users to long-press to store only the subject or tap a button to store the full image as a task image
- Refactored TravelPlanDetailView to match the fast, modern UI and UX of NewTravelPlanView, ensuring uniformity across plan creation and editing
- Introduced in-memory local editing state for plan fields and tasks, preventing SwiftData lag and enabling smooth, instant updates
- Added clear distinction between view and edit modes:
  - Default mode allows checking off tasks and marking plan as complete with "I'm All Set" button
  - Edit mode triggered by pencil icon; all fields and tasks become editable with a toolbar checkmark to save and a Cancel button to discard edits
- Refined task row layout and subject image handling for modern iOS look
- Eliminated duplicate navigation/cancel buttons; all actions are in appropriate toolbar locations
- All edits are batch-committed on save, minimizing unnecessary database writes
- Consistent UX for plan creation, editing, and task completion