### PR TITLE
FRGT-1

### DIFF
--- a/ForgetMeNot/Common/Utils.swift
+++ b/ForgetMeNot/Common/Utils.swift
@@ -1,0 +1,10 @@
+enum ImagePickerSheet: Identifiable {
+    case camera, photoLibrary
+    var id: Int { hashValue }
+}//
+//  Utils.swift
+//  ForgetMeNot
+//
+//  Created by Mainul Hossain on 8/5/25.
+//
+


### PR DESCRIPTION
Resolved critical image sheet bug:
Fixed the issue where the subject lifting sheet was not shown on first use of the camera or gallery during task editing. Now, the image picker and subject lift flow work flawlessly every time, not just after the first dismissal.

Improved task editing performance:
Refactored editing logic so task text fields are instantly responsive and lag-free, matching the experience in the plan creation view.

Refined plan title editing:
Split out plan title editing from the main form to minimize SwiftUI recomputation and reduce lag.

Enhanced task UI alignment:
Left-aligned all task titles in non-edit mode for a cleaner, more consistent appearance.

Kept user on detail page after save:
Changed edit flow so saving changes no longer navigates away from the plan details page.

General cleanup:
Removed unnecessary variables and simplified sheet state logic.