### PR TITLE
FRGT-10: Cancelling on camera or gallery choice exits the whole plan creation

### DIFF
--- a/ForgetMeNot/Features/CalendarProcessing/NotesDetailView.swift
+++ b/ForgetMeNot/Features/CalendarProcessing/NotesDetailView.swift
@@ -12,7 +12,7 @@ struct NotesDetailView: View {
     @State private var isLoading = true
 
     var body: some View {
-        NavigationStack {
+        
             ZStack {
                 ScrollView {
                     Text(notes)
@@ -44,6 +44,6 @@ struct NotesDetailView: View {
                     isLoading = false
                 }
             }
-        }
+        
     }
 }

--- a/ForgetMeNot/Features/TravelPlan/NewTravelPlanView.swift
+++ b/ForgetMeNot/Features/TravelPlan/NewTravelPlanView.swift
@@ -62,7 +62,7 @@ struct NewTravelPlanView: View {
     var onDone: (TravelPlan?) -> Void
 
     var body: some View {
-        NavigationStack {
+    
             ScrollView(.vertical, showsIndicators: false) {
                 VStack(spacing: 22) {
                     // PLAN DETAILS CARD
@@ -244,11 +244,7 @@ struct NewTravelPlanView: View {
                         )
                         .foregroundColor(.blue)
                 }
-                ToolbarItem(placement: .cancellationAction) {
-                    Button("Cancel") { cancel() }
-                        .font(.system(size: 15, weight: .regular))
-                        .foregroundColor(.secondary)
-                }
+                
             }
             .alert("Plan name is required.", isPresented: $showNameError) {
                 Button("OK", role: .cancel) {}
@@ -266,7 +262,7 @@ struct NewTravelPlanView: View {
                 }
                 Button("Cancel", role: .cancel) { }
             }
-        }
+        
         .onChange(of: activeImagePickerSheet) {
             if activeImagePickerSheet == nil, imageToLift != nil {
                 DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
@@ -310,7 +306,7 @@ struct NewTravelPlanView: View {
         modelContext.insert(plan)
         NotificationHelper.scheduleTravelReminder(for: plan, offset: reminderOffset)
         onDone(plan)
-        dismiss()
+        
     }
 
     private func cancel() {

--- a/ForgetMeNot/Features/TravelPlan/TravelPlanDetailView.swift
+++ b/ForgetMeNot/Features/TravelPlan/TravelPlanDetailView.swift
@@ -32,7 +32,7 @@ struct TravelPlanDetailView: View {
     @State private var showCompletedAlert = false
 
     var body: some View {
-        NavigationStack {
+
             ScrollView(.vertical, showsIndicators: false) {
                 VStack(spacing: 20) {
                     // PLAN DETAILS CARD
@@ -183,36 +183,36 @@ struct TravelPlanDetailView: View {
             .navigationTitle("Plan Details")
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
-                ToolbarItem(placement: .navigationBarTrailing) {
-                    if !plan.isCompleted {
-                        if isEditing {
-                            Button {
-                                saveEdits()
-                            } label: {
-                                Image(systemName: "checkmark.circle.fill")
-                                    .font(.system(size: 22, weight: .bold))
-                                    .foregroundColor(.green)
-                            }
-                        } else {
-                            Button {
-                                enterEditMode()
-                            } label: {
-                                Image(systemName: "square.and.pencil")
-                                    .font(.system(size: 22, weight: .bold))
-                                    .foregroundColor(.blue)
-                            }
-                        }
-                    }
-                }
-                ToolbarItem(placement: .navigationBarLeading) {
-                    if isEditing {
-                        Button("Cancel") {
+                ToolbarItemGroup(placement: .navigationBarTrailing) {
+                    if !plan.isCompleted && isEditing {
+                        // Cancel (cross)
+                        Button {
                             cancelEdits()
+                        } label: {
+                            Image(systemName: "xmark.circle.fill")
+                                .font(.system(size: 22, weight: .bold))
+                                .foregroundColor(.red)
                         }
-                        .font(.system(size: 15, weight: .regular))
+                        // Save (check)
+                        Button {
+                            saveEdits()
+                        } label: {
+                            Image(systemName: "checkmark.circle.fill")
+                                .font(.system(size: 22, weight: .bold))
+                                .foregroundColor(.green)
+                        }
+                    } else if !plan.isCompleted && !isEditing {
+                        Button {
+                            enterEditMode()
+                        } label: {
+                            Image(systemName: "square.and.pencil")
+                                .font(.system(size: 22, weight: .bold))
+                                .foregroundColor(.blue)
+                        }
                     }
                 }
             }
+
             .alert("Plan name is required.", isPresented: $showNameError) {
                 Button("OK", role: .cancel) {}
             }
@@ -235,7 +235,7 @@ struct TravelPlanDetailView: View {
                 }
                 Button("Cancel", role: .cancel) { }
             }
-        }
+        
         .sheet(item: $activeImagePickerSheet) { source in
             FMNImagePicker(sourceType: source == .camera ? .camera : .photoLibrary) { img in
                 if let img = img {

--- a/ForgetMeNot/Root/ContentView.swift
+++ b/ForgetMeNot/Root/ContentView.swift
@@ -1,109 +1,97 @@
 import SwiftUI
 import SwiftData
 
-struct ContentView: View {
-    
+// --- Path Destination Enum ---
+enum AppNav: Hashable {
+    case newPlan
+    case allUpcoming
+    case planDetail(TravelPlan)
+}
 
+struct ContentView: View {
     @Query(sort: \TravelPlan.date, order: .forward) var plans: [TravelPlan]
     @Environment(\.modelContext) private var modelContext
 
-    @State private var showNewPlan = false
-    @State private var selectedPlan: TravelPlan?
-    
-    @State private var showAllUpcoming = false
-
+    @State private var navPath = NavigationPath()
+    @State private var planToOpen: TravelPlan?
+    @State private var newPlanParams: (planName: String?, travelDate: Date?, reminderDate: Date?, tasks: [TravelTask]?) = (nil, nil, nil, nil)
 
     var body: some View {
-        NavigationStack {
+        NavigationStack(path: $navPath) {
             ScrollView {
                 VStack(spacing: 0) {
                     // Header Card
                     VStack(spacing: 4) {
-                        
-
-                            Text("🧳ForgetMeNot")
-                                .font(.system(size: 28, weight: .bold, design: .monospaced))
-                                .foregroundColor(.accentColor)
-                                .shadow(color: .accentColor.opacity(0.04), radius: 2, y: 1)
-                                .padding(.bottom, 2)
-                            Text("Let your iPhone remember important details!")
-                                .foregroundColor(.secondary)
-                                .font(.system(size: 14, weight: .medium, design: .monospaced))
-                                .multilineTextAlignment(.center)
-                        }
-                        .padding(.vertical, 18)
-                        .padding(.horizontal, 12)
-                        .background(
-                            RoundedRectangle(cornerRadius: 16, style: .continuous)
-                                .fill(Color(.systemBackground).opacity(0.72))
-                                .shadow(color: .accentColor.opacity(0.09), radius: 5, y: 2)
-                        )
-                        .padding(.horizontal, 14)
-                        .padding(.top, 22)
-
-                        // Sleek Modern Buttons
-                        HStack(spacing: 10) {
-                            Button {
-                                showNewPlan = true
-                            } label: {
-                                HStack(spacing: 6) {
-                                    Image(systemName: "plus.circle.fill")
-                                    Text("New Plan")
-                                }
-                                .font(.system(size: 16, weight: .semibold))
-                                .padding(.vertical, 10)
-                                .padding(.horizontal, 18)
-                                .background(
-                                    Capsule()
-                                        .fill(
-                                            LinearGradient(
-                                                colors: [Color.accentColor.opacity(0.15), Color.blue.opacity(0.12)],
-                                                startPoint: .topLeading, endPoint: .bottomTrailing
-                                            )
-                                        )
-                                )
-                            }
+                        Text("🧳ForgetMeNot")
+                            .font(.system(size: 28, weight: .bold, design: .monospaced))
                             .foregroundColor(.accentColor)
-                            .buttonStyle(.plain)
-                            .sheet(isPresented: $showNewPlan) {
-                                NewTravelPlanView { newPlan in
-                                    if let plan = newPlan { selectedPlan = plan }
-                                    showNewPlan = false
-                                }
-                            }
+                            .shadow(color: .accentColor.opacity(0.04), radius: 2, y: 1)
+                            .padding(.bottom, 2)
+                        Text("Let your iPhone remember important details!")
+                            .foregroundColor(.secondary)
+                            .font(.system(size: 14, weight: .medium, design: .monospaced))
+                            .multilineTextAlignment(.center)
+                    }
+                    .padding(.vertical, 18)
+                    .padding(.horizontal, 12)
+                    .background(
+                        RoundedRectangle(cornerRadius: 16, style: .continuous)
+                            .fill(Color(.systemBackground).opacity(0.72))
+                            .shadow(color: .accentColor.opacity(0.09), radius: 5, y: 2)
+                    )
+                    .padding(.horizontal, 14)
+                    .padding(.top, 22)
 
-                            Button {
-                                showAllUpcoming = true
-                            } label: {
-                                HStack(spacing: 6) {
-                                    Image(systemName: "rectangle.stack")
-                                    Text("From Calendar")
-                                }
-                                .font(.system(size: 16, weight: .semibold))
-                                .padding(.vertical, 10)
-                                .padding(.horizontal, 18)
-                                .background(
-                                    Capsule()
-                                        .fill(
-                                            LinearGradient(
-                                                colors: [Color.blue.opacity(0.14), Color.accentColor.opacity(0.13)],
-                                                startPoint: .topLeading, endPoint: .bottomTrailing
-                                            )
+                    // Sleek Modern Buttons
+                    HStack(spacing: 10) {
+                        Button {
+                            navPath.append(AppNav.newPlan)
+                        } label: {
+                            HStack(spacing: 6) {
+                                Image(systemName: "plus.circle.fill")
+                                Text("New Plan")
+                            }
+                            .font(.system(size: 16, weight: .semibold))
+                            .padding(.vertical, 10)
+                            .padding(.horizontal, 18)
+                            .background(
+                                Capsule()
+                                    .fill(
+                                        LinearGradient(
+                                            colors: [Color.accentColor.opacity(0.15), Color.blue.opacity(0.12)],
+                                            startPoint: .topLeading, endPoint: .bottomTrailing
                                         )
-                                )
-                            }
-                            .foregroundColor(.accentColor)
-                            .buttonStyle(.plain)
-                            .sheet(isPresented: $showAllUpcoming) {
-                                NavigationStack {
-                                    AllUpcomingView(calendarManager: CalendarManager())
-                                }
-                            }
+                                    )
+                            )
                         }
-                        .padding(.top, 4)
-                        .padding(.horizontal, 18)
+                        .foregroundColor(.accentColor)
+                        .buttonStyle(.plain)
 
-
+                        Button {
+                            navPath.append(AppNav.allUpcoming)
+                        } label: {
+                            HStack(spacing: 6) {
+                                Image(systemName: "rectangle.stack")
+                                Text("From Calendar")
+                            }
+                            .font(.system(size: 16, weight: .semibold))
+                            .padding(.vertical, 10)
+                            .padding(.horizontal, 18)
+                            .background(
+                                Capsule()
+                                    .fill(
+                                        LinearGradient(
+                                            colors: [Color.blue.opacity(0.14), Color.accentColor.opacity(0.13)],
+                                            startPoint: .topLeading, endPoint: .bottomTrailing
+                                        )
+                                    )
+                            )
+                        }
+                        .foregroundColor(.accentColor)
+                        .buttonStyle(.plain)
+                    }
+                    .padding(.top, 4)
+                    .padding(.horizontal, 18)
 
                     // Sections
                     let incompletePlans = plans.filter { !$0.isCompleted }
@@ -131,14 +119,11 @@ struct ContentView: View {
                                         plan: plan,
                                         isCompleted: false,
                                         onTap: {
-                                        selectedPlan = plan
+                                            navPath.append(AppNav.planDetail(plan))
                                         },
                                         onDelete: { deepDeleteTravelPlan(plan, modelContext: modelContext) }
                                     )
                                 }
-
-                                
-
                             }
                             .padding(.horizontal, 14)
                         }
@@ -154,11 +139,10 @@ struct ContentView: View {
                                         plan: plan,
                                         isCompleted: true,
                                         onTap: {
-                                        selectedPlan = plan
+                                            navPath.append(AppNav.planDetail(plan))
                                         },
                                         onDelete: { deepDeleteTravelPlan(plan, modelContext: modelContext) }
                                     )
-                                    
                                 }
                             }
                             .padding(.horizontal, 14)
@@ -170,12 +154,31 @@ struct ContentView: View {
                 }
             }
             .background(Color(.systemGroupedBackground).ignoresSafeArea())
-            .navigationDestination(item: $selectedPlan) { plan in
-                TravelPlanDetailView(plan: plan)
+            .navigationDestination(for: AppNav.self) { destination in
+                switch destination {
+                case .newPlan:
+                    NewTravelPlanView { newPlan in
+                        if let plan = newPlan {
+                            navPath.removeLast(navPath.count)      // Pop all the way home
+                            navPath.append(AppNav.planDetail(plan)) // Show plan details
+                        } else {
+                            navPath.removeLast(navPath.count)      // Pop all the way home if cancelled
+                        }
+                    }
+
+                case .allUpcoming:
+                    AllUpcomingView(
+                        calendarManager: CalendarManager(),
+                        navPath: $navPath // pass binding!
+                    )
+                case .planDetail(let plan):
+                    TravelPlanDetailView(plan: plan)
+                }
             }
         }
     }
 }
+
 
 // MARK: - Section Header
 struct SectionHeader: View {


### PR DESCRIPTION


- Fixed navigation flow so that cancelling image selection (camera or gallery) now exits the entire plan creation process, ensuring a consistent and intuitive user experience.
- Unified navigation path handling for plan creation and calendar event flows.
- Removed all nested NavigationStack instances and standardized navigation with AppNav enum and navPath for robust and predictable stack behavior.
- Modernized edit/cancel toolbar for plan details with cross and checkmark icons side-by-side.